### PR TITLE
Remove entrypoint, cmd and expose

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -11,9 +11,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.label-schema.vendor="ownCloud GmbH" \
   org.label-schema.schema-version="1.0"
 
-EXPOSE 9110 9114
-
-ENTRYPOINT ["/usr/bin/ocis-migration"]
-CMD ["server"]
-
 COPY bin/ocis-migration /usr/bin/ocis-migration

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -11,9 +11,4 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.label-schema.vendor="ownCloud GmbH" \
   org.label-schema.schema-version="1.0"
 
-EXPOSE 9110 9114
-
-ENTRYPOINT ["/usr/bin/ocis-migration"]
-CMD ["server"]
-
 COPY bin/ocis-migration /usr/bin/ocis-migration

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -11,9 +11,6 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.label-schema.vendor="ownCloud GmbH" \
   org.label-schema.schema-version="1.0"
 
-EXPOSE 9110 9114
 
-ENTRYPOINT ["/usr/bin/ocis-migration"]
-CMD ["server"]
 
 COPY bin/ocis-migration /usr/bin/ocis-migration


### PR DESCRIPTION
Migration is a collection of commands which is not launching any service. Thus this is a command-only docker-image.